### PR TITLE
support `win32` file formats

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,9 +1,10 @@
 const R = require('ramda');
 
-const METADATA_START = /^---\n/;
-const METADATA_END = /\n---\n/;
-const METADATA_FILE_END = /\n---$/;
-const JOIN_SEPARATOR = '\n---\n';
+const isWin32 = process.platform === 'win32';
+const METADATA_START = isWin32 ? /^---\r\n/ : /^---\n/;
+const METADATA_END = isWin32 ? /\r\n---\r\n/ : /\n---\n/;
+const METADATA_FILE_END = isWin32 ? /\r\n---$/ : /\n---$/;
+const JOIN_SEPARATOR = isWin32 ? '\r\n---\r\n' : '\n---\n';
 
 /**
  * Check if the provided array has only one element that ends with METADATA_FILE_END.


### PR DESCRIPTION
This PR is intended to add support for the Windows platform. On Windows, the newline is represented as `\r\n`.