### PR TITLE
fix platform os family bug that causes package import to fail when null

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,7 @@
 const platform = require('platform');
 const R = require('ramda');
 
-const isWin = R.includes('Windows', platform.os.family);
+const isWin = R.includes('Windows', platform.os.family || "");
 const METADATA_START = isWin ? /^---\r\n/ : /^---\n/;
 const METADATA_END = isWin ? /\r\n---\r\n/ : /\n---\n/;
 const METADATA_FILE_END = isWin ? /\r\n---$/ : /\n---$/;


### PR DESCRIPTION
## Problem

PlatformJS sometimes returns null when `platform.os.family` is requested. This causes the usage of `markdown-yaml-metadata-parser` to fail because RamdaJS tries to check for the presence of "Windows" on null. Please see `lib/parser.js`.

## Fix

Default to an empty string when `platform.os.family` is null.