### PR TITLE
This is a complete rewrite of the parser but using the same algorithm

### DIFF
--- a/__tests__/parser.test.js
+++ b/__tests__/parser.test.js
@@ -53,17 +53,7 @@ it("throws TypeError if it doesn't receive a String for src parameter", () => {
   );
 });
 
-it("throws TypeError if it receives an empty configuration", () => {
-  function parseNumber() {
-    parser(yamlParser)("123", {});
-  }
-
-  expect(parseNumber).toThrowError(
-    TypeError('Configuration can\'t be empty.')
-  );
-});
-
-it("throws TypeError if it doesn't receive a boolean as windows configuration", () => {
+it("throws TypeError if configuration is set but windows prop is not boolean", () => {
   function parseNumber() {
     parser(yamlParser)("123", { windows: "true" });
   }

--- a/__tests__/parser.test.js
+++ b/__tests__/parser.test.js
@@ -43,13 +43,33 @@ it('returns no metadata in a document without metadata', () => {
   expect(parser(yamlParser)(source.document07)).toMatchSnapshot();
 });
 
-it("throws TypeError if it doesn't receive a String", () => {
+it("throws TypeError if it doesn't receive a String for src parameter", () => {
   function parseNumber() {
     parser(yamlParser)(123);
   }
 
   expect(parseNumber).toThrowError(
     TypeError('Source parameter (src) must be a string.')
+  );
+});
+
+it("throws TypeError if it receives an empty configuration", () => {
+  function parseNumber() {
+    parser(yamlParser)("123", {});
+  }
+
+  expect(parseNumber).toThrowError(
+    TypeError('Configuration can\'t be empty.')
+  );
+});
+
+it("throws TypeError if it doesn't receive a boolean as windows configuration", () => {
+  function parseNumber() {
+    parser(yamlParser)("123", { windows: "true" });
+  }
+
+  expect(parseNumber).toThrowError(
+    TypeError('Configuration property (windows) must be a boolean.')
   );
 });
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,7 @@
 const platform = require('platform');
 const R = require('ramda');
 
-const isWin = R.includes('Windows', platform.os.family);
+const isWin = R.includes('Windows', platform.os.family || "");
 const METADATA_START = isWin ? /^---\r\n/ : /^---\n/;
 const METADATA_END = isWin ? /\r\n---\r\n/ : /\n---\n/;
 const METADATA_FILE_END = isWin ? /\r\n---$/ : /\n---$/;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -119,7 +119,7 @@ const parse = yamlParser => (src, config = { }) => {
 
   validateInput(src, config)
 
-  defaultConfig.src = src;
+  defaultConfig.src = src.trim();
 
   if(config.windows) {
     defaultConfig.windows = config.windows;
@@ -135,8 +135,8 @@ const parse = yamlParser => (src, config = { }) => {
   const getContent = R.compose(joinContent, splitSource);
 
   return {
-    metadata: getMetadata(src),
-    content: getContent(src)
+    metadata: getMetadata(defaultConfig.src),
+    content: getContent(defaultConfig.src)
   };
 };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,11 +1,14 @@
-const platform = require('platform');
 const R = require('ramda');
 
-const isWin = R.includes('Windows', platform.os.family || "");
-const METADATA_START = isWin ? /^---\r\n/ : /^---\n/;
-const METADATA_END = isWin ? /\r\n---\r\n/ : /\n---\n/;
-const METADATA_FILE_END = isWin ? /\r\n---$/ : /\n---$/;
-const JOIN_SEPARATOR = isWin ? '\r\n---\r\n' : '\n---\n';
+/**
+ * The default configuration to be used when no configuration was passed in by the caller.
+ */
+let defaultConfig = { windows: false }
+
+const METADATA_START = () => defaultConfig.windows ? /^---\r\n/ : /^---\n/;
+const METADATA_END = () => defaultConfig.windows ? /\r\n---\r\n/ : /\n---\n/;
+const METADATA_FILE_END = () => defaultConfig.windows ? /\r\n---$/ : /\n---$/;
+const JOIN_SEPARATOR = () => defaultConfig.windows ? '\r\n---\r\n' : '\n---\n';
 
 /**
  * Check if the provided array has only one element that ends with METADATA_FILE_END.
@@ -15,8 +18,8 @@ const JOIN_SEPARATOR = isWin ? '\r\n---\r\n' : '\n---\n';
  * @returns {Array}
  */
 const checkMetadataOnly = R.ifElse(
-  R.both(R.compose(R.equals(1), R.length), R.test(METADATA_FILE_END)),
-  R.compose(R.append(''), R.of, R.replace(METADATA_FILE_END, ''), R.head),
+  R.both(R.compose(R.equals(1), R.length), R.test(METADATA_FILE_END())),
+  R.compose(R.append(''), R.of, R.replace(METADATA_FILE_END(), ''), R.head),
   R.identity
 );
 
@@ -28,13 +31,13 @@ const checkMetadataOnly = R.ifElse(
  * @returns {Array}
  */
 const splitSource = R.ifElse(
-  R.test(METADATA_START),
-  R.compose(checkMetadataOnly, R.split(METADATA_END)),
+  R.test(METADATA_START()),
+  R.compose(checkMetadataOnly, R.split(METADATA_END())),
   R.of
 );
 
 /**
- * If source array has more than one value, it cleans (remove METADATA_START and trim) and returns the first one.
+ * If source array has more than one value, it cleans (remove METADATA_START() and trim) and returns the first one.
  * Otherwise it returns null.
  *
  * @param {Array.<string>}
@@ -42,7 +45,7 @@ const splitSource = R.ifElse(
  */
 const cleanMetadata = R.ifElse(
   R.compose(R.lt(1), R.length),
-  R.compose(R.trim, R.replace(METADATA_START, ''), R.head),
+  R.compose(R.trim, R.replace(METADATA_START(), ''), R.head),
   () => null
 );
 
@@ -63,9 +66,30 @@ const emptyObjectIfNil = R.ifElse(R.isNil, () => ({}), R.identity);
  */
 const joinContent = R.ifElse(
   R.compose(R.lt(1), R.length),
-  R.compose(R.join(JOIN_SEPARATOR), R.drop(1)),
+  R.compose(R.join(JOIN_SEPARATOR()), R.drop(1)),
   R.head
 );
+
+/**
+ * Validate incoming input.
+ * 
+ * @param {string} src Document source to parse.
+ * @param {{windows: Boolean}} config Operation configuration.
+ */
+
+const validateInput = (src, config) => {
+  if (!R.is(String, src)) {
+    throw new TypeError('Source parameter (src) must be a string.');
+  }
+
+  if (Object.keys(config).length === 0) {
+    throw new TypeError('Configuration can\'t be empty.');
+  }
+
+  if (!R.is(Boolean, config.windows)) {
+    throw new TypeError('Configuration property (windows) must be a boolean.');
+  }
+}
 
 /**
  * Parse a markdown document (src) looking for metadata in YAML format.
@@ -79,14 +103,16 @@ const joinContent = R.ifElse(
  *
  * @param {{safeLoad: Function}} yamlParser YAMLParser object with safeLoad function.
  * @param {string} src Document source to parse.
+ * @param {{windows: Boolean}} config Operation configuration.
  * @returns {{metadata: Object, content: string}}
  * @throws {TypeError} src must be a string.
  * @throws {YAMLException} Error on YAML metadata parsing.
  */
-const parse = yamlParser => src => {
-  if (!R.is(String, src)) {
-    throw new TypeError('Source parameter (src) must be a string.');
-  }
+const parse = yamlParser => (src, config = defaultConfig) => {
+
+  validateInput(src, config)
+
+  defaultConfig = R.clone(config);
 
   const getMetadata = R.compose(
     emptyObjectIfNil,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,15 +1,21 @@
 const R = require('ramda');
-const platform = require('platform');
 
 /**
- * The default configuration to be used when no configuration was passed in by the caller.
+ * The configuration to be used for operation
  */
-let defaultConfig = { windows: R.includes('Windows', platform.os) }
+const defaultConfig = { 
+  src: "", 
+  windows: false, 
+  // infer the platform type by the eol present in the source string
+  isWin: () => defaultConfig.windows || defaultConfig.src.match(/\r\n/) !== null  
+}
 
-const METADATA_START = () => defaultConfig.windows ? /^---\r\n/ : /^---\n/;
-const METADATA_END = () => defaultConfig.windows ? /\r\n---\r\n/ : /\n---\n/;
-const METADATA_FILE_END = () => defaultConfig.windows ? /\r\n---$/ : /\n---$/;
-const JOIN_SEPARATOR = () => defaultConfig.windows ? '\r\n---\r\n' : '\n---\n';
+Object.seal(defaultConfig);
+
+const METADATA_START = () => defaultConfig.isWin() ? /^---\r\n/ : /^---\n/;
+const METADATA_END = () => defaultConfig.isWin() ? /\r\n---\r\n/ : /\n---\n/;
+const METADATA_FILE_END = () => defaultConfig.isWin() ? /\r\n---$/ : /\n---$/;
+const JOIN_SEPARATOR = () => defaultConfig.isWin() ? '\r\n---\r\n' : '\n---\n';
 
 /**
  * Check if the provided array has only one element that ends with METADATA_FILE_END.
@@ -83,11 +89,7 @@ const validateInput = (src, config) => {
     throw new TypeError('Source parameter (src) must be a string.');
   }
 
-  if (Object.keys(config).length === 0) {
-    throw new TypeError('Configuration can\'t be empty.');
-  }
-
-  if (!R.is(Boolean, config.windows)) {
+  if (Object.keys(config).length > 0 && !R.is(Boolean, config.windows)) {
     throw new TypeError('Configuration property (windows) must be a boolean.');
   }
 }
@@ -101,6 +103,9 @@ const validateInput = (src, config) => {
  * author: Marcus Antonius
  * keywords: latin, ipsum
  * ---
+ * 
+ * NB: setting windows to true in configuration prop will override the ability 
+ * to infer the type from the document (src)
  *
  * @param {{safeLoad: Function}} yamlParser YAMLParser object with safeLoad function.
  * @param {string} src Document source to parse.
@@ -109,11 +114,15 @@ const validateInput = (src, config) => {
  * @throws {TypeError} src must be a string.
  * @throws {YAMLException} Error on YAML metadata parsing.
  */
-const parse = yamlParser => (src, config = defaultConfig) => {
+const parse = yamlParser => (src, config = { }) => {
 
   validateInput(src, config)
 
-  defaultConfig = R.clone(config);
+  defaultConfig.src = src;
+
+  if(config.windows) {
+    defaultConfig.windows = config.windows;
+  }
 
   const getMetadata = R.compose(
     emptyObjectIfNil,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,14 +1,17 @@
-const R = require('ramda');
-const platform = require('platform')
+const platform = require('platform');
 
 /**
  * The configuration to be used for operation
  */
-const defaultConfig = { 
-  src: "", 
-  windows: false, 
+const defaultConfig = {
+  src: "",
+  windows: false,
   // infer the platform type by the eol present in the source string
-  isWin: () => (defaultConfig.windows || R.includes('Windows', platform.os) || defaultConfig.src.match(/\r\n/) !== null  )
+  isWin: () => (
+    defaultConfig.windows
+    || platform.os.toString().indexOf('Windows') !== -1
+    || defaultConfig.src.match(/\r\n/) !== null
+  )
 }
 
 Object.seal(defaultConfig);
@@ -25,24 +28,26 @@ const JOIN_SEPARATOR = () => defaultConfig.isWin() ? '\r\n---\r\n' : '\n---\n';
  * @param {Array}
  * @returns {Array}
  */
-const checkMetadataOnly = R.ifElse(
-  R.both(R.compose(R.equals(1), R.length), R.test(METADATA_FILE_END())),
-  R.compose(R.append(''), R.of, R.replace(METADATA_FILE_END(), ''), R.head),
-  R.identity
-);
+const checkMetadataOnly = (src) => {
+  if (src.length === 1 && src[0].match(METADATA_FILE_END()) !== null) {
+    return [src[0].replace(METADATA_FILE_END(), ''), ''];
+  }
+  return src;
+}
 
 /**
  * Split a string with the METADATA_END separator if it starts with METADATA_START.
- * Otherwise it creates a singleton array containing the source string provided.
+ * Otherwise it creates an array containing the source string provided.
  *
  * @param {string} Source string to split.
  * @returns {Array}
  */
-const splitSource = R.ifElse(
-  R.test(METADATA_START()),
-  R.compose(checkMetadataOnly, R.split(METADATA_END())),
-  R.of
-);
+const splitSource = (src) => {
+  if (src.match(METADATA_START()) !== null) {
+    return checkMetadataOnly(src.split(METADATA_END()))
+  }
+  return [src];
+}
 
 /**
  * If source array has more than one value, it cleans (remove METADATA_START() and trim) and returns the first one.
@@ -51,11 +56,12 @@ const splitSource = R.ifElse(
  * @param {Array.<string>}
  * @returns {string|null}
  */
-const cleanMetadata = R.ifElse(
-  R.compose(R.lt(1), R.length),
-  R.compose(R.trim, R.replace(METADATA_START(), ''), R.head),
-  () => null
-);
+const cleanMetadata = (src) => {
+  if (src.length >= 1) {
+    return src[0].replace(METADATA_START(), '').trim();
+  }
+  return null;
+}
 
 /**
  * If the supplied value is nil, it returns an empty object, otherwise it returns the value itself.
@@ -63,7 +69,7 @@ const cleanMetadata = R.ifElse(
  * @param {*}
  * @returns {*}
  */
-const emptyObjectIfNil = R.ifElse(R.isNil, () => ({}), R.identity);
+const emptyObjectIfNil = (src) => src.length === 0 ? {} : src
 
 /**
  * Join the elements of the array except the first one (metadata).
@@ -72,11 +78,12 @@ const emptyObjectIfNil = R.ifElse(R.isNil, () => ({}), R.identity);
  * @param {Array.<string>}
  * @returns {string}
  */
-const joinContent = R.ifElse(
-  R.compose(R.lt(1), R.length),
-  R.compose(R.join(JOIN_SEPARATOR()), R.drop(1)),
-  R.head
-);
+const joinContent = (srcLines) => {
+  if (srcLines.length > 1) {
+    return srcLines.slice(1, srcLines.length).join(JOIN_SEPARATOR());
+  }
+  return srcLines.join('');
+}
 
 /**
  * Validate incoming input.
@@ -86,11 +93,11 @@ const joinContent = R.ifElse(
  */
 
 const validateInput = (src, config) => {
-  if (!R.is(String, src)) {
+  if (typeof src !== "string") {
     throw new TypeError('Source parameter (src) must be a string.');
   }
 
-  if (Object.keys(config).length > 0 && !R.is(Boolean, config.windows)) {
+  if (Object.keys(config).length > 0 && typeof config.windows !== "boolean") {
     throw new TypeError('Configuration property (windows) must be a boolean.');
   }
 }
@@ -115,28 +122,27 @@ const validateInput = (src, config) => {
  * @throws {TypeError} src must be a string.
  * @throws {YAMLException} Error on YAML metadata parsing.
  */
-const parse = yamlParser => (src, config = { }) => {
+const parse = yamlParser => (src, config = {}) => {
 
   validateInput(src, config)
 
   defaultConfig.src = src.trim();
 
-  if(config.windows) {
+  if (config.windows) {
     defaultConfig.windows = config.windows;
   }
 
-  const getMetadata = R.compose(
-    emptyObjectIfNil,
-    yamlParser.safeLoad,
-    cleanMetadata,
-    splitSource
-  );
+  const splittedSource = splitSource(defaultConfig.src);
 
-  const getContent = R.compose(joinContent, splitSource);
+  const cleanedMetadata = cleanMetadata(splittedSource);
+  const parsedYaml = yamlParser.safeLoad(cleanedMetadata);
+  const metaData = emptyObjectIfNil(parsedYaml);
+
+  const content = joinContent(splittedSource);
 
   return {
-    metadata: getMetadata(defaultConfig.src),
-    content: getContent(defaultConfig.src)
+    metadata: metaData,
+    content: content
   };
 };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,9 +1,10 @@
 const R = require('ramda');
+const platform = require('platform');
 
 /**
  * The default configuration to be used when no configuration was passed in by the caller.
  */
-let defaultConfig = { windows: false }
+let defaultConfig = { windows: R.includes('Windows', platform.os) }
 
 const METADATA_START = () => defaultConfig.windows ? /^---\r\n/ : /^---\n/;
 const METADATA_END = () => defaultConfig.windows ? /\r\n---\r\n/ : /\n---\n/;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,4 +1,5 @@
 const R = require('ramda');
+const platform = require('platform')
 
 /**
  * The configuration to be used for operation
@@ -7,7 +8,7 @@ const defaultConfig = {
   src: "", 
   windows: false, 
   // infer the platform type by the eol present in the source string
-  isWin: () => defaultConfig.windows || defaultConfig.src.match(/\r\n/) !== null  
+  isWin: () => (defaultConfig.windows || R.includes('Windows', platform.os) || defaultConfig.src.match(/\r\n/) !== null  )
 }
 
 Object.seal(defaultConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4454,9 +4454,9 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-      "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-yaml-metadata-parser",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3187,11 +3187,6 @@
       "requires": {
         "find-up": "^4.0.0"
       }
-    },
-    "platform": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
-      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
     },
     "pn": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3267,11 +3267,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "ramda": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
-      "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA=="
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3188,6 +3188,11 @@
         "find-up": "^4.0.0"
       }
     },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
+    },
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
     "test": "jest --coverage",
     "prettier": "prettier --single-quote true --write 'lib/**/*.js' '__tests__/**/*.js'"
   },
-  "version": "2.0.5"
+  "version": "2.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "bugs": "https://github.com/ninjabachelor/markdown-yaml-metadata-parser/issues",
   "dependencies": {
     "js-yaml": "^3.13.1",
+    "platform": "^1.3.5",
     "ramda": "^0.27.0"
   },
   "description": "Parse YAML metadata in a markdown document",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "bugs": "https://github.com/ninjabachelor/markdown-yaml-metadata-parser/issues",
   "dependencies": {
     "js-yaml": "^3.13.1",
-    "platform": "^1.3.5",
     "ramda": "^0.27.0"
   },
   "description": "Parse YAML metadata in a markdown document",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "bugs": "https://github.com/ninjabachelor/markdown-yaml-metadata-parser/issues",
   "dependencies": {
     "js-yaml": "^3.13.1",
-    "platform": "^1.3.5",
-    "ramda": "^0.27.0"
+    "platform": "^1.3.5"
   },
   "description": "Parse YAML metadata in a markdown document",
   "devDependencies": {


### PR DESCRIPTION
## Why?

If you look at PR #11 , an insidious bug is introduced when allowing the users supply the configurations and allowing the package infer the platform type on the fly. The user may provide a configuration but that will NEVER be used during function call time as the parser module is already resolved and values assigned to the variables, just in the way the modules get resolved and evaluated in JS, therefore misleading the user.

Please correct me if I'm wrong, but this bug is simply because the package was built with functional programming. To my understanding, at least with the way RamdaJS works, this prevents dynamism with regards the provision of state since functions are "precomposed" with their arguments.

## Fix

I simply rewrote the parser based on the same algorithm but with a different programming approach. We now have a structure that allows users explicitly supply a configuration while we're still also able to infer the platform type from the markdown string provided or through platformjs (I highly suggest that this be removed).

## Considerations

If there is any reason that functional programming style has to be maintained, then it would be great that the introduced feature be implemented and the bug fixed with FP because I was just unable to achieve the same with FP.