### PR TITLE
Fixed Bug Preventing Script to Work on Windows

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,7 @@
 const platform = require('platform');
 const R = require('ramda');
 
-const isWin = R.includes('Windows', platform.os.family);
+const isWin = R.includes('Win', platform.os.family);
 const METADATA_START = isWin ? /^---\r\n/ : /^---\n/;
 const METADATA_END = isWin ? /\r\n---\r\n/ : /\n---\n/;
 const METADATA_FILE_END = isWin ? /\r\n---$/ : /\n---$/;


### PR DESCRIPTION
I was having a lot of trouble running this on Windows 10.  I found out that this code:

```javascript
platform.os.family
```

was returning **Win 32** instead of something that contains the full word **Windows**.  This PR changes the code to simply search for an os family that contains **Win**.